### PR TITLE
Fixed URI endpoint Github GraphQL API v4

### DIFF
--- a/server/index.js
+++ b/server/index.js
@@ -7,7 +7,7 @@ const setContext = require('apollo-link-context').setContext;
 require('dotenv').config();
 
 const httpLink = createHttpLink({
-    uri: "https://api.github.com/graphql/v4",
+    uri: "https://api.github.com/graphql",
     fetch: fetch
 });
 

--- a/src/index.js
+++ b/src/index.js
@@ -12,7 +12,7 @@ console.log('token: ', token);
 
 const client = new ApolloClient({
   // uri: "https://48p1r2roz4.sse.codesandbox.io",
-  uri: "https://api.github.com/graphql/v4",
+  uri: "https://api.github.com/graphql",
   // uri: "/graphql/v4/",
   request: async operation => {
     // const token = localStorage.getItem('token');


### PR DESCRIPTION
According to [the docs](https://developer.github.com/v4/guides/forming-calls/#the-graphql-endpoint) the URI for v4's single endpoint is `https://api.github.com/graphql`.